### PR TITLE
Add cron to certbot tasks

### DIFF
--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -26,3 +26,11 @@
         - www.noisebridge.social
   tags:
     - certbot
+
+- name: automatically renew certificates
+  cron:  
+    name: "renew certificates"
+    job: 'certbot renew --pre-hook "service nginx stop" --post-hook "service nginx start"'
+    special_time: monthly
+  tags:
+    - certbot


### PR DESCRIPTION
Addresses #1 . Some adjustments might be needed.

TODO:
- Are we happy with doing this monthly?
- Does NGINX actually need to go down as a pre-hook? Can we just restart
on success?